### PR TITLE
Fixed return type in mixin to match the function

### DIFF
--- a/shared/src/main/java/net/blay09/mods/craftingforblockheads/mixin/RecipeManagerMixin.java
+++ b/shared/src/main/java/net/blay09/mods/craftingforblockheads/mixin/RecipeManagerMixin.java
@@ -1,5 +1,6 @@
 package net.blay09.mods.craftingforblockheads.mixin;
 
+import com.mojang.datafixers.util.Pair;
 import net.blay09.mods.craftingforblockheads.tag.ModItemTags;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.Container;
@@ -31,11 +32,11 @@ public class RecipeManagerMixin {
     }
 
     @Inject(method = "getRecipeFor(Lnet/minecraft/world/item/crafting/RecipeType;Lnet/minecraft/world/Container;Lnet/minecraft/world/level/Level;Lnet/minecraft/resources/ResourceLocation;)Ljava/util/Optional;", at = @At("RETURN"), cancellable = true)
-    public void getRecipeFor(RecipeType<?> recipeType, Container container, Level level, @Nullable ResourceLocation resourceLocation, CallbackInfoReturnable<Optional<Recipe<?>>> callbackInfo) {
+    public void getRecipeFor(RecipeType<?> recipeType, Container container, Level level, @Nullable ResourceLocation resourceLocation, CallbackInfoReturnable<Optional<Pair<ResourceLocation, Recipe<?>>>> callbackInfo) {
         final var result = callbackInfo.getReturnValue();
         if (result.isPresent()) {
             final var recipe = result.get();
-            final var resultItem = recipe.getResultItem(level.registryAccess());
+            final var resultItem = recipe.getSecond().getResultItem(level.registryAccess());
             if (resultItem.is(ModItemTags.IS_WORKSHOP_EXCLUSIVE)) {
                 callbackInfo.setReturnValue(Optional.empty());
             }


### PR DESCRIPTION
This PR fixes a crash when using the `RecipeManager.CachedCheck` for recipes.
`CachedCheck` uses the `getRecipeFor` that also takes a `ResourceLocation`.

This is the crash:
```log
java.lang.ClassCastException: class com.mojang.datafixers.util.Pair cannot be cast to class net.minecraft.world.item.crafting.Recipe (com.mojang.datafixers.util.Pair is in module datafixerupper@6.0.8 of loader 'MC-BOOTSTRAP' @e7edb54; net.minecraft.world.item.crafting.Recipe is in module minecraft@1.20.1 of loader 'TRANSFORMER' @59b3f754)
at net.minecraft.world.item.crafting.RecipeManager.handler$dfj000$getRecipeFor(RecipeManager.java:4537) ~[client-1.20.1-20230612.114412-srg.jar%23762!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.world.item.crafting.RecipeManager.m_220248_(RecipeManager.java:107) ~[client-1.20.1-20230612.114412-srg.jar%23762!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.world.item.crafting.RecipeManager$1.m_213657_(RecipeManager.java:200) ~[client-1.20.1-20230612.114412-srg.jar%23762!/:?] {re:classloading}
```

The signature of the function that the mixin affects.
```java
public <C extends Container, T extends Recipe<C>> Optional<Pair<ResourceLocation, T>> getRecipeFor(RecipeType<T> recipeType, C container, Level level, @Nullable ResourceLocation resourceLocation) {}
```