### PR TITLE
Changed to sending available filters as a separate packet

### DIFF
--- a/shared/src/main/java/net/blay09/mods/craftingforblockheads/CraftingForBlockheads.java
+++ b/shared/src/main/java/net/blay09/mods/craftingforblockheads/CraftingForBlockheads.java
@@ -16,7 +16,7 @@ import net.blay09.mods.craftingforblockheads.item.ModItems;
 import net.blay09.mods.craftingforblockheads.menu.WorkshopMenu;
 import net.blay09.mods.craftingforblockheads.network.ModNetworking;
 import net.blay09.mods.craftingforblockheads.block.entity.ModBlockEntities;
-import net.blay09.mods.craftingforblockheads.network.WorkshopFilterSerialization;
+import net.blay09.mods.craftingforblockheads.network.message.WorkshopFiltersMessage;
 import net.blay09.mods.craftingforblockheads.registry.CraftingForBlockheadsRegistry;
 import net.blay09.mods.craftingforblockheads.registry.json.JsonCompatLoader;
 import net.blay09.mods.craftingforblockheads.tag.ModBlockTags;
@@ -234,15 +234,15 @@ public class CraftingForBlockheads {
 
                     @Override
                     public void writeScreenOpeningData(ServerPlayer player, FriendlyByteBuf buf) {
-                        final var workshop = new WorkshopImpl(level, pos);
-                        final var fulfilledPredicates = workshop.getFulfilledPredicates(player);
-                        final var availableFilters = workshop.getAvailableFilters(fulfilledPredicates);
                         buf.writeBlockPos(pos);
-                        WorkshopFilterSerialization.writeAvailableFilters(buf, availableFilters);
                     }
                 });
                 event.setResult(InteractionResult.SUCCESS);
                 event.setCanceled(true);
+
+                if (player instanceof ServerPlayer) {
+                    Balm.getNetworking().sendTo(player, new WorkshopFiltersMessage(new WorkshopImpl(level, pos), player));
+                }
             }
         });
 
@@ -266,15 +266,15 @@ public class CraftingForBlockheads {
 
                     @Override
                     public void writeScreenOpeningData(ServerPlayer player, FriendlyByteBuf buf) {
-                        final var workshop = new WorkshopImpl(itemStack);
-                        final var fulfilledPredicates = workshop.getFulfilledPredicates(player);
-                        final var availableFilters = workshop.getAvailableFilters(fulfilledPredicates);
                         buf.writeItem(itemStack);
-                        WorkshopFilterSerialization.writeAvailableFilters(buf, availableFilters);
                     }
                 });
                 event.setResult(InteractionResult.SUCCESS);
                 event.setCanceled(true);
+
+                if (player instanceof ServerPlayer) {
+                    Balm.getNetworking().sendTo(player, new WorkshopFiltersMessage(new WorkshopImpl(itemStack), player));
+                }
             }
         });
     }

--- a/shared/src/main/java/net/blay09/mods/craftingforblockheads/block/WorkbenchBlock.java
+++ b/shared/src/main/java/net/blay09/mods/craftingforblockheads/block/WorkbenchBlock.java
@@ -3,6 +3,8 @@ package net.blay09.mods.craftingforblockheads.block;
 import net.blay09.mods.balm.api.Balm;
 import net.blay09.mods.craftingforblockheads.CraftingForBlockheads;
 import net.blay09.mods.craftingforblockheads.block.entity.WorkbenchBlockEntity;
+import net.blay09.mods.craftingforblockheads.crafting.WorkshopImpl;
+import net.blay09.mods.craftingforblockheads.network.message.WorkshopFiltersMessage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
@@ -47,6 +49,7 @@ public class WorkbenchBlock extends BlockDyeableKitchen {
 
         if (!level.isClientSide) {
             Balm.getNetworking().openGui(player, blockEntity);
+            Balm.getNetworking().sendTo(player, new WorkshopFiltersMessage(new WorkshopImpl(level, pos), player));
         }
 
         return InteractionResult.SUCCESS;

--- a/shared/src/main/java/net/blay09/mods/craftingforblockheads/menu/ModMenus.java
+++ b/shared/src/main/java/net/blay09/mods/craftingforblockheads/menu/ModMenus.java
@@ -3,19 +3,9 @@ package net.blay09.mods.craftingforblockheads.menu;
 import net.blay09.mods.balm.api.DeferredObject;
 import net.blay09.mods.balm.api.menu.BalmMenus;
 import net.blay09.mods.craftingforblockheads.CraftingForBlockheads;
-import net.blay09.mods.craftingforblockheads.api.ItemFilter;
-import net.blay09.mods.craftingforblockheads.api.WorkshopFilter;
 import net.blay09.mods.craftingforblockheads.crafting.WorkshopImpl;
-import net.blay09.mods.craftingforblockheads.network.WorkshopFilterSerialization;
-import net.blay09.mods.craftingforblockheads.registry.IngredientItemFilter;
-import net.blay09.mods.craftingforblockheads.registry.NbtIngredientItemFilter;
-import net.blay09.mods.craftingforblockheads.registry.RecipeFilter;
-import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.MenuType;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -30,15 +20,13 @@ public class ModMenus {
             final var level = inv.player.level();
             final var pos = data.readBlockPos();
             final var workshop = new WorkshopImpl(level, pos);
-            final var availableFilters = WorkshopFilterSerialization.readAvailableFilters(data);
-            return new WorkshopMenu(workbench.get(), windowId, inv.player, availableFilters, workshop);
+            return new WorkshopMenu(workbench.get(), windowId, inv.player, new HashMap<>(), workshop);
         });
 
         workbenchItem = menus.registerMenu(id("workbench_item"), (windowId, inv, data) -> {
             final var itemStack = data.readItem();
             final var workshop = new WorkshopImpl(itemStack);
-            final var availableFilters = WorkshopFilterSerialization.readAvailableFilters(data);
-            return new WorkshopMenu(workbenchItem.get(), windowId, inv.player, availableFilters, workshop);
+            return new WorkshopMenu(workbenchItem.get(), windowId, inv.player, new HashMap<>(), workshop);
         });
     }
 

--- a/shared/src/main/java/net/blay09/mods/craftingforblockheads/menu/WorkshopMenu.java
+++ b/shared/src/main/java/net/blay09/mods/craftingforblockheads/menu/WorkshopMenu.java
@@ -49,7 +49,7 @@ public class WorkshopMenu extends AbstractContainerMenu {
     private Comparator<RecipeWithStatus> currentSorting = new CraftableComparator();
 
     private List<RecipeWithStatus> craftables = new ArrayList<>();
-    private final Map<String, WorkshopFilterWithStatus> availableFilters;
+    private Map<String, WorkshopFilterWithStatus> availableFilters;
 
     private boolean craftablesDirty = true;
     private boolean recipesDirty = true;
@@ -65,12 +65,7 @@ public class WorkshopMenu extends AbstractContainerMenu {
         this.player = player;
         this.workshop = workshop;
 
-        this.availableFilters = availableFilters;
-        currentFilter = availableFilters.values().stream()
-                .filter(WorkshopFilterWithStatus::available)
-                .map(WorkshopFilterWithStatus::filter)
-                .max(Comparator.comparing(WorkshopFilter::getPriority))
-                .orElse(null);
+        setAvailableFilters(availableFilters);
 
         Container fakeInventory = new DefaultContainer(5 * 4 + 3 * 3);
 
@@ -681,6 +676,16 @@ public class WorkshopMenu extends AbstractContainerMenu {
         if (selectedCraftable != null) {
             requestRecipes(selectedCraftable);
         }
+    }
+
+    public void setAvailableFilters(Map<String, WorkshopFilterWithStatus> availableFilters) {
+        this.availableFilters = availableFilters;
+
+        currentFilter = availableFilters.values().stream()
+                .filter(WorkshopFilterWithStatus::available)
+                .map(WorkshopFilterWithStatus::filter)
+                .max(Comparator.comparing(WorkshopFilter::getPriority))
+                .orElse(null);
     }
 
     public Map<String, WorkshopFilterWithStatus> getAvailableFilters() {

--- a/shared/src/main/java/net/blay09/mods/craftingforblockheads/network/ModNetworking.java
+++ b/shared/src/main/java/net/blay09/mods/craftingforblockheads/network/ModNetworking.java
@@ -13,6 +13,7 @@ public class ModNetworking {
         networking.registerServerboundPacket(id("request_recipes"), RequestRecipesMessage.class, RequestRecipesMessage::encode, RequestRecipesMessage::decode, RequestRecipesMessage::handle);
         networking.registerServerboundPacket(id("craft_recipe"), CraftRecipeMessage.class, CraftRecipeMessage::encode, CraftRecipeMessage::decode, CraftRecipeMessage::handle);
 
+        networking.registerClientboundPacket(id("filters"), WorkshopFiltersMessage.class, WorkshopFiltersMessage::encode, WorkshopFiltersMessage::decode, WorkshopFiltersMessage::handle);
         networking.registerClientboundPacket(id("craftables"), CraftablesListMessage.class, CraftablesListMessage::encode, CraftablesListMessage::decode, CraftablesListMessage::handle);
         networking.registerClientboundPacket(id("recipes"), RecipesListMessage.class, RecipesListMessage::encode, RecipesListMessage::decode, RecipesListMessage::handle);
     }

--- a/shared/src/main/java/net/blay09/mods/craftingforblockheads/network/message/WorkshopFiltersMessage.java
+++ b/shared/src/main/java/net/blay09/mods/craftingforblockheads/network/message/WorkshopFiltersMessage.java
@@ -1,0 +1,40 @@
+package net.blay09.mods.craftingforblockheads.network.message;
+
+import net.blay09.mods.craftingforblockheads.crafting.WorkshopImpl;
+import net.blay09.mods.craftingforblockheads.menu.WorkshopFilterWithStatus;
+import net.blay09.mods.craftingforblockheads.menu.WorkshopMenu;
+import net.blay09.mods.craftingforblockheads.network.WorkshopFilterSerialization;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
+import java.util.Map;
+
+public class WorkshopFiltersMessage {
+
+    private final Map<String, WorkshopFilterWithStatus> availableFilters;
+
+    public WorkshopFiltersMessage(WorkshopImpl workshop, Player player) {
+        final var fulfilledPredicates = workshop.getFulfilledPredicates(player);
+        this.availableFilters = workshop.getAvailableFilters(fulfilledPredicates);
+    }
+
+    public WorkshopFiltersMessage(Map<String, WorkshopFilterWithStatus> availableFilters) {
+        this.availableFilters = availableFilters;
+    }
+
+    public static WorkshopFiltersMessage decode(FriendlyByteBuf buf) {
+        return new WorkshopFiltersMessage(WorkshopFilterSerialization.readAvailableFilters(buf));
+    }
+
+    public static void encode(WorkshopFiltersMessage msg, FriendlyByteBuf buf) {
+        WorkshopFilterSerialization.writeAvailableFilters(buf, msg.availableFilters);
+    }
+
+    public static void handle(Player player, WorkshopFiltersMessage message) {
+        AbstractContainerMenu container = player.containerMenu;
+        if (container instanceof WorkshopMenu) {
+            ((WorkshopMenu) container).setAvailableFilters(message.availableFilters);
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the workshop filters to a separate packet when opening the GUI.

This is because if you have many filters and/or multiple blocks connected the data amount exceeds the limit of the `NetworkHooks.openScreen` function of 32600 bytes. This limit is only present in Forge.

This is an error when that happens:
```log
[Server thread/ERROR]: Failed to handle packet net.minecraft.network.protocol.game.ServerboundUseItemOnPacket@7bae83e5, suppressing error
java.lang.IllegalArgumentException: Invalid PacketBuffer for openGui, found 53481 bytes
at net.minecraftforge.network.NetworkHooks.openScreen(NetworkHooks.java:202) ~[forge-1.20.1-47.3.10-universal.jar%23760!/:?]
at net.blay09.mods.balm.forge.network.ForgeBalmNetworking.openGui(ForgeBalmNetworking.java:56) ~[balm-forge-1.20.1-7.3.9-all.jar%23466!/:7.3.9]
at net.blay09.mods.craftingforblockheads.CraftingForBlockheads.lambda$initialize$20(CraftingForBlockheads.java:221) ~[craftingforblockheads-forge-20.1.1-20241004.142135-3.jar%23509!/:20.1.1-SNAPSHOT]
at net.blay09.mods.balm.forge.event.ForgeBalmEvents.fireEventHandler(ForgeBalmEvents.java:50) ~[balm-forge-1.20.1-7.3.9-all.jar%23466!/:7.3.9]
at net.blay09.mods.balm.forge.event.ForgeBalmEvents.lambda$fireEventHandlers$0(ForgeBalmEvents.java:44) ~[balm-forge-1.20.1-7.3.9-all.jar%23466!/:7.3.9]
```