### PR TITLE
Fix the search bar breaking whenever you click on a tab. 

### DIFF
--- a/common/src/main/java/net/blay09/mods/craftingforblockheads/client/gui/screen/WorkshopScreen.java
+++ b/common/src/main/java/net/blay09/mods/craftingforblockheads/client/gui/screen/WorkshopScreen.java
@@ -151,6 +151,7 @@ public class WorkshopScreen extends AbstractContainerScreen<WorkshopMenu> {
             return true;
         } else {
             if (searchBar.mouseClicked(mouseX, mouseY, button)) {
+                searchBar.setFocused(true);
                 return true;
             }
         }
@@ -181,7 +182,7 @@ public class WorkshopScreen extends AbstractContainerScreen<WorkshopMenu> {
 
     @Override
     public boolean charTyped(char c, int keyCode) {
-        boolean result = super.charTyped(c, keyCode);
+        boolean result = searchBar.charTyped(c, keyCode);
 
         menu.search(searchBar.getValue());
         menu.updateCraftableSlots();
@@ -203,6 +204,8 @@ public class WorkshopScreen extends AbstractContainerScreen<WorkshopMenu> {
             setCurrentOffset(currentOffset);
             return true;
         }
+        
+        
 
         return super.keyPressed(keyCode, scanCode, modifiers);
     }

--- a/common/src/main/java/net/blay09/mods/craftingforblockheads/client/gui/screen/WorkshopScreen.java
+++ b/common/src/main/java/net/blay09/mods/craftingforblockheads/client/gui/screen/WorkshopScreen.java
@@ -151,7 +151,7 @@ public class WorkshopScreen extends AbstractContainerScreen<WorkshopMenu> {
             return true;
         } else {
             if (searchBar.mouseClicked(mouseX, mouseY, button)) {
-                searchBar.setFocused(true);
+                setFocused(searchBar);
                 return true;
             }
         }
@@ -182,7 +182,7 @@ public class WorkshopScreen extends AbstractContainerScreen<WorkshopMenu> {
 
     @Override
     public boolean charTyped(char c, int keyCode) {
-        boolean result = searchBar.charTyped(c, keyCode);
+        boolean result = super.charTyped(c, keyCode);
 
         menu.search(searchBar.getValue());
         menu.updateCraftableSlots();
@@ -204,8 +204,6 @@ public class WorkshopScreen extends AbstractContainerScreen<WorkshopMenu> {
             setCurrentOffset(currentOffset);
             return true;
         }
-        
-        
 
         return super.keyPressed(keyCode, scanCode, modifiers);
     }


### PR DESCRIPTION
Fixes #33 
This makes it so when you click the search bar it focuses it.